### PR TITLE
Manage ~/.claude (Claude Code settings) with chezmoi

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -2,3 +2,18 @@ setup
 setup.ps1
 win_main_apps.json
 README.md
+
+# === Claude Code (~/.claude) ===
+# Allowlist 方針: 自分で書いた設定だけを追跡し、
+# 認証情報・セッション履歴・ランタイム状態は絶対に含めない。
+# パターンはターゲットパス（$HOME からの相対）で評価される。
+# `chezmoi add ~/.claude` 時にもこの無視リストが適用されることを確認済み
+# （マッチしたものは "ignoring ..." と表示され、ソースに取り込まれない）。
+.claude/.credentials.json
+.claude/settings.local.json
+.claude/projects/
+.claude/todos/
+.claude/shell-snapshots/
+.claude/statsig/
+.claude/history.jsonl
+.claude/ide/

--- a/README.md
+++ b/README.md
@@ -43,10 +43,80 @@ ToDo
 * wezterm muxまわり設定
 * im-select VSCode vi mode IME設定
 
+Claude Code 設定 (~/.claude)
+-----------------------------
+Claude Code のユーザー設定を chezmoi で複数端末に共有する。
+方針は **allowlist**：自分で書いた設定だけを追跡し、認証情報・セッション履歴・
+ランタイム状態は **絶対にコミットしない**。
+
+### レイアウト（ソース命名規則）
+
+| ソース（このリポジトリ）            | 反映先                         | 備考                       |
+| ----------------------------------- | ------------------------------ | -------------------------- |
+| `dot_claude/`                       | `~/.claude/`                   | `dot_` → 先頭ドット        |
+| `dot_claude/settings.json.tmpl`     | `~/.claude/settings.json`      | テンプレート（後述）       |
+| `dot_claude/CLAUDE.md`              | `~/.claude/CLAUDE.md`          | ローカルで `chezmoi add`   |
+| `dot_claude/commands/`              | `~/.claude/commands/`          | ローカルで `chezmoi add`   |
+| `dot_claude/agents/`                | `~/.claude/agents/`            | ローカルで `chezmoi add`   |
+| `dot_claude/skills/`                | `~/.claude/skills/`            | ローカルで `chezmoi add`   |
+
+このクラウド/CI 環境からは実際の `~/.claude` が見えないため、コミットされているのは
+`settings.json.tmpl`（無難な既定値の雛形）のみ。`CLAUDE.md` や `commands/` などの
+実ファイルは、各自のマシンで下記コマンドを実行してソースへ取り込むこと。
+
+```bash
+# 自分の実ファイルをソースへ取り込む（.chezmoiignore は自動で適用される）
+chezmoi add ~/.claude/CLAUDE.md
+chezmoi add ~/.claude/commands ~/.claude/agents ~/.claude/skills
+
+# settings.json をテンプレートとして取り込み直したい場合
+chezmoi add --template ~/.claude/settings.json
+```
+
+`chezmoi add ~/.claude` とディレクトリごと渡しても、除外対象（下表）は
+`ignoring ...` と表示されて取り込まれないことを、利用中の chezmoi で確認済み。
+
+### 追跡する / 除外する
+
+* **追跡**: `settings.json`, `CLAUDE.md`, `commands/`, `agents/`, `skills/`,
+  （任意で）プラグイン設定
+* **除外**（`.chezmoiignore` に記載。ターゲットパス＝`$HOME` 相対で評価される）
+  * `.claude/.credentials.json` … 認証トークン。**秘密。絶対にコミットしない**
+  * `.claude/settings.local.json` … 端末ローカル上書き
+  * `.claude/projects/` … セッション履歴（巨大・端末固有）
+  * `.claude/todos/`, `.claude/shell-snapshots/`, `.claude/statsig/`,
+    `.claude/history.jsonl`, `.claude/ide/` … ランタイム状態・キャッシュ
+
+### settings.json のテンプレート化と端末固有の上書き
+
+端末差分が出やすい `model` は `settings.json.tmpl` でテンプレート化している。
+既定値は `claude-sonnet-4-6`。端末ごとに変えたいときは、その端末の
+`~/.config/chezmoi/chezmoi.toml`（chezmoi のローカル設定、リポジトリには入らない）に
+データを書く：
+
+```toml
+[data.claude]
+model = "claude-opus-4-8"
+```
+
+`dig` で未設定時は既定値にフォールバックするため、データ未定義の端末でも安全に描画される。
+
+### 反映手順（apply）
+
+```bash
+chezmoi diff          # 反映前に差分を確認
+chezmoi apply ~/.claude
+```
+
+> ⚠️ `settings.json.tmpl` は雛形。`chezmoi apply` すると既存の
+> `~/.claude/settings.json` を上書きするため、初回は必ず `chezmoi diff` で確認し、
+> 自分の設定を取り込んでから運用すること。
+
 学び
 -----------------------------
 * chezmoiってsymlinkでなくてコピーなのね
 * コピー先ファイルの変更はchezmoi addで再反映する
+* `.chezmoiignore` は `chezmoi add` 時にも効く（マッチは取り込まれない）
 
 このdotfiles/setupで対象にしないこと
 -----------------------------

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -1,0 +1,18 @@
+{{- /*
+  ~/.claude/settings.json (user 設定) — chezmoi 管理。
+  端末差分が出やすい値は chezmoi のデータ経由で上書きする。
+
+  既定値: model = "claude-sonnet-4-6"
+  端末固有の上書き: ~/.config/chezmoi/chezmoi.toml に以下を書く
+
+      [data.claude]
+      model = "claude-opus-4-8"
+
+  `dig` で未設定時に既定値へフォールバックするため、データ未定義でも安全に描画される。
+*/ -}}
+{{- $model := dig "claude" "model" "claude-sonnet-4-6" . -}}
+{
+  "model": {{ $model | quote }},
+  "includeCoAuthoredBy": true,
+  "cleanupPeriodDays": 30
+}


### PR DESCRIPTION
## 概要
Claude Code のユーザー設定 (`~/.claude`) を chezmoi 管理下に入れ、複数端末で共有する。方針は **allowlist**：自分で書いた設定だけを追跡し、認証情報・セッション履歴・ランタイム状態は含めない。

## 変更点
- **`.chezmoiignore`**: 認証情報・セッション履歴・ランタイム状態を除外
  - `.claude/.credentials.json`, `.claude/settings.local.json`, `.claude/projects/`, `.claude/todos/`, `.claude/shell-snapshots/`, `.claude/statsig/`, `.claude/history.jsonl`, `.claude/ide/`
- **`dot_claude/settings.json.tmpl`**: ユーザー設定の雛形。既定 `model = claude-sonnet-4-6`、端末ごとに `~/.config/chezmoi/chezmoi.toml` の `[data.claude].model` で上書き可（`dig` で安全にフォールバック）
- **`README.md`**: レイアウト・追跡/除外の対象・model 上書き方法・apply 手順を追記

## 検証（インストール済み chezmoi で実挙動を確認）
- `chezmoi add ~/.claude` は **`.chezmoiignore` を尊重**し、マッチしたものは `ignoring …` と表示して取り込まない（credentials/projects/todos 等が除外されることを確認）
- 無視パターンは **`$HOME` 相対のターゲットパス**で評価。ディレクトリは末尾 `/`、単一ファイルはそのまま、どちらも動作
- `dot_claude/settings.json.tmpl` は既定値・上書き双方で **valid JSON** を生成
- `chezmoi managed` は `.claude` と `.claude/settings.json` のみを管理対象とし、除外項目は管理されない

## 注意 / 未対応（ローカルでの作業が必要）
- このクラウドセッションからは実際の `~/.claude` が見えないため、`CLAUDE.md` / `commands/` / `agents/` / `skills/` の実ファイルは含めていない。各自のマシンで `chezmoi add ~/.claude/CLAUDE.md` 等で取り込むこと（README に手順あり）
- `settings.json.tmpl` は雛形。`chezmoi apply` は既存の `~/.claude/settings.json` を上書きするため、初回は `chezmoi diff` で確認し自分の設定を取り込んでから運用すること

https://claude.ai/code/session_01D46yLVZQxmSR27n6WA46FR

---
_Generated by [Claude Code](https://claude.ai/code/session_01D46yLVZQxmSR27n6WA46FR)_