### PR TITLE
Telegram 経由の通知経路を追加する仕様（OpenSpec 提案 / 実装は未着手）

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -2,6 +2,9 @@ setup
 setup.ps1
 win_main_apps.json
 README.md
+# OpenSpec の変更管理ディレクトリ。リポジトリ内のドキュメントであり
+# $HOME に配布するものではないので追跡対象から外す。
+openspec
 
 # === Claude Code (~/.claude) ===
 # Allowlist 方針: 自分で書いた設定だけを追跡し、

--- a/openspec/changes/add-telegram-notify-transport/.openspec.yaml
+++ b/openspec/changes/add-telegram-notify-transport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/add-telegram-notify-transport/design.md
+++ b/openspec/changes/add-telegram-notify-transport/design.md
@@ -23,7 +23,7 @@ hook(JSON) → claude-notify-hook → claude-notify-nag（grace/繰り返し）
 **Goals:**
 - SSH 先 / devcontainer から、ポート転送も自前サーバも無しに「手元の VOICEVOX で発話」を成立させる。
 - 同じ 1 通でスマホにも通知が届く（外出時は Telegram 通知だけで用が足りる）。
-- 既存 `voice` モードと排他選択でき、既定は現行動作（非破壊）。
+- 既存 `voice` モードと排他選択でき、既定は `telegram`（未配線端末は `voice` へフォールバックするので無音にはならない）。
 - 追加パッケージ無し（bash + curl + Python 3 標準ライブラリ）。
 - 秘密の置き場所は既存方式（`chezmoi.toml` の `[data.claudeNotify]` → `config.env`）に揃える。
 
@@ -79,9 +79,11 @@ hook(JSON) → claude-notify-hook → claude-notify-nag（grace/繰り返し）
 - 2 行目のマーカーで「Claude Code 由来か」を判定する。人間の雑談や他アプリの投稿を誤って読み上げない防壁であり、将来 `kind` で挙動を分けるための拡張点でもある。`#claude_notify` をハッシュタグにしてあるので Telegram 側の検索・フィルタでも使える。
 - `parse_mode` は指定しない。Markdown/HTML パースを有効にすると、リポジトリ名に `_` や `*` が含まれた瞬間に 400 で送信失敗する。
 
-### D4: モードは `CLAUDE_NOTIFY_MODE`（`voice` | `telegram`、既定 `voice`）
+### D4: モードは `CLAUDE_NOTIFY_MODE`（`telegram` | `voice`、既定 `telegram`）
 
-- 置き場所は既存様式に合わせて `~/.config/claude-notify/config.env`（`chezmoi.toml` の `[data.claudeNotify] mode`）。端末ごとに切り替わるのが自然（Mac は `voice`、devcontainer は `telegram` など）。
+- 置き場所は既存様式に合わせて `~/.config/claude-notify/config.env`（`chezmoi.toml` の `[data.claudeNotify] mode`）。端末ごとに上書きできる。
+- **既定は `telegram`**。Telegram 経路が「どの環境でも同じ手順で動く」唯一の経路なので、これを標準に据え、手元で直接鳴らしたい端末だけ `mode = "voice"` で opt-out する。既定を `voice` にしておくと、通知が欲しい環境（SSH / devcontainer）ほど毎回追加設定が要るという逆転が起きる。
+- 既定変更の副作用として「Telegram を配線していない端末が無音になる」ため、`telegram` かつトークン / チャット ID が空のときだけ `voice` へフォールバックする（警告 1 行付き）。厳密な択一（未設定ならベルのみ）にすると、`chezmoi apply` した瞬間に全端末が黙るため実用に耐えない。逆に「設定済みだが送信失敗」では `voice` へ落とさない（リモートでは案1/案2 を無駄に叩いてフックが遅くなるだけ）。
 - **`config.env` は `${VAR:-...}` 形式で出力する**。現行の `config.env` は `KEY="value"` で無条件代入しており、`. config.env` が既存の環境変数を踏み潰す。一時的な切り戻し（`CLAUDE_NOTIFY_MODE=voice claude-notify ...`）とデバッグを成立させるため、新規キーは環境変数優先で書き出す。
 - 不正値は `voice` として扱い警告のみ。通知系スクリプトがフックを失敗させてはならないため、どの失敗経路でも終了コードは 0。
 
@@ -108,7 +110,8 @@ Windows の停止処理は PID ファイル方式にする。既存 `claude-noti
 ## Risks / Trade-offs
 
 - **[最大リスク] チャンネル自動転送が受信 Bot に届かない可能性** → 実装着手前に curl だけで実機検証する（tasks 1.x）。成立しなければ案 B（Telethon 受信）へ差し替える。設計上、送信側の仕様（D3/D4/D5）と受信側の受理条件以外は共通なので、差し替え範囲は受信常駐 1 本に閉じる。
-- **通知内容が Telegram のサーバを経由する** → 本文はリポジトリ名・ホスト名・セッション ID 先頭 8 文字・固定文言のみに限定（`telegram-notify-send` の要件）。プロンプトやツール出力は送らない。それでも「どのリポジトリでいつ作業したか」は Telegram 上に残るため、`voice` モードを既定に据えたまま opt-in とする。
+- **既定変更で既存端末の経路が切り替わる** → 未配線端末は `voice` へフォールバックするため無音にはならない。ただし「Telegram を配線した端末は以後ローカルで喋らなくなる」ので、README に `mode = "voice"` での固定手順とロールバック手順を明記する。
+- **通知内容が Telegram のサーバを経由する** → 本文はリポジトリ名・ホスト名・セッション ID 先頭 8 文字・固定文言のみに限定（`telegram-notify-send` の要件）。プロンプトやツール出力は送らない。それでも「どのリポジトリでいつ作業したか」は Telegram 上に残る。既定が `telegram` である以上これは全端末に及ぶため、README のセキュリティ節で明示し、嫌な端末は `mode = "voice"` で opt-out できるようにする。
 - **送信 Bot トークンをリモートにも置く** → 権限はチャンネル投稿のみ。受信 Bot トークンは手元だけに置き、漏洩範囲を分離する（D2）。チャンネルは非公開にする。
 - **フック終端が最大 5 秒ブロックする**（`CLAUDE_TELEGRAM_TIMEOUT`） → 既存の案1 経路（4 秒）と同程度。回線不調時の体感悪化が許容できなければ、この値を下げるか将来的に非同期送信へ変更する。
 - **同一受信トークンの二重ポーリングで 409** → マシンごとに受信 Bot を分ける運用をドキュメント化し、常駐側は 409 を検知したらバックオフして警告を残す。
@@ -120,8 +123,8 @@ Windows の停止処理は PID ファイル方式にする。既存 `claude-noti
 1. **実機検証（実装前）**: BotFather で送信 Bot・受信 Bot を作成、非公開チャンネルとディスカッショングループを作成して連携、送信 Bot をチャンネル管理者、受信 Bot をグループへ（プライバシーモード無効）。curl で `sendMessage`（チャンネル宛）→ `getUpdates`（受信 Bot）を叩き、`is_automatic_forward` / `sender_chat` 付きで取得できることを確認する。
 2. 失敗した場合は design を更新し、受信側を案 B（Telethon）に差し替える。送信側仕様と設定キーはそのまま流用する。
 3. 実装は「設定 → 送信側 → 受信側 → setup 結線 → ドキュメント」の順。各段階で `voice` モードの回帰（Mac ローカル発話、devcontainer の案1）を確認する。
-4. 展開は端末ごとに `chezmoi.toml` の `mode` を切り替えるだけ。ロールバックは `mode = "voice"` に戻して `chezmoi apply`（受信常駐は残っていても、送信が止まれば発話しない）。常駐を消すなら `claude-notify-telegram-bot uninstall`。
-5. 既存端末は `mode` 未設定 = `voice` なので、`chezmoi apply` しても挙動は変わらない。
+4. 展開は「手元マシンに受信常駐を入れる → 各端末の `chezmoi.toml` に送信トークンとチャット ID を入れて `chezmoi apply`」の順。`mode` は既定 `telegram` なので通常は書かない。ロールバックは `mode = "voice"` を書いて `chezmoi apply`（受信常駐は残っていても、送信が止まれば発話しない）。常駐を消すなら `claude-notify-telegram-bot uninstall`。
+5. 既存端末は `mode` 未設定でも `telegram` になる。トークン未投入の間は `voice` へフォールバックするため無音にはならず、配線した端末から順に Telegram 経路へ移る（段階移行が可能）。
 
 ## Open Questions
 

--- a/openspec/changes/add-telegram-notify-transport/design.md
+++ b/openspec/changes/add-telegram-notify-transport/design.md
@@ -1,0 +1,131 @@
+## Context
+
+現状の通知経路（`dot_local/bin/`）:
+
+```
+hook(JSON) → claude-notify-hook → claude-notify-nag（grace/繰り返し）
+                                → claude-notify
+                                     ├ macOS      : VOICEVOX(:50021) → say
+                                     ├ native Win : powershell → claude-notify.ps1 → VOICEVOX → SAPI5
+                                     ├ WSL2       : powershell interop → 〃
+                                     └ container/SSH : 案1 daemon(:50090) → 案2 ntfy → ベル
+```
+
+制約と前提:
+
+- **Bot は他 Bot および自分自身が送信したメッセージを `getUpdates` で受信できない**（Telegram の仕様。ループ防止のため「bots will ignore messages coming from other bots」）。したがって「フックが Bot で送信 → 同じ／別の Bot が読んで発話」という素直な構成は成立しない。リレーには「送信者が Bot ではない」identity を挟む必要がある。
+- リモート側（devcontainer / SSH）は使い捨てで、対話ログインや長期セッションファイルを置きたくない。逆に手元マシン（Mac/Win）は常駐を持てる。
+- 既存スクリプトは bash + Python 3 標準ライブラリのみで書かれており、`config.env`（chezmoi テンプレート）で秘密を渡す方式が確立している。この様式を崩さない。
+- 既存 `voice` 経路を壊さないことが最優先。既定値は現行動作のままとする。
+
+## Goals / Non-Goals
+
+**Goals:**
+- SSH 先 / devcontainer から、ポート転送も自前サーバも無しに「手元の VOICEVOX で発話」を成立させる。
+- 同じ 1 通でスマホにも通知が届く（外出時は Telegram 通知だけで用が足りる）。
+- 既存 `voice` モードと排他選択でき、既定は現行動作（非破壊）。
+- 追加パッケージ無し（bash + curl + Python 3 標準ライブラリ）。
+- 秘密の置き場所は既存方式（`chezmoi.toml` の `[data.claudeNotify]` → `config.env`）に揃える。
+
+**Non-Goals:**
+- Telegram から Claude Code を操作する（返信で指示を送る、`/mute` 等のコマンド）機能。将来拡張として設計上妨げないだけに留める。
+- 案1（HTTP デーモン）/ 案2（ntfy）の置き換え・削除。`voice` モードとして残す。
+- Linux デスクトップを受信側にすること（受信側は macOS / Windows のみ）。
+- 通知内容の充実化（差分要約、ツール名、所要時間などの送信）。本文は既存発話文＋最小メタデータに限定する。
+- `voice` と `telegram` の同時実行（`both`）。要望どおり択一とする。
+
+## Decisions
+
+### D1: リレー構成は「チャンネル → 連携ディスカッショングループ」を採用（採用案 A）
+
+```
+リモート/ローカルの hook
+   └─ 送信Bot(sendMessage) ──> 非公開チャンネル      … スマホ通知はここから届く
+                                    │ Telegram が自動転送（sender_chat = チャンネル）
+                                    ▼
+                              連携ディスカッショングループ
+                                    │ getUpdates（長ポーリング）
+                                    ▼
+                              受信Bot = claude-notify-telegram-bot（手元 Mac/Win 常駐）
+                                    └─ claude-notify / claude-notify.ps1 → VOICEVOX
+```
+
+チャンネル投稿が連携グループへ自動転送されると、グループ側のメッセージは「チャンネルが送信者」（`sender_chat` = チャンネル、`is_automatic_forward` = true）として扱われるため、Bot でも受信できる。これが「Bot は Bot のメッセージを読めない」制約を回避する唯一の Bot API 内の手段。
+
+**検討した代替案:**
+
+- **案 B: 受信側を Telethon（ユーザーアカウント）にする** — 送信は Bot の `sendMessage`、受信は手元 PC で自分の Telegram アカウントとしてログインして Bot のメッセージを読む。Telegram 側の設定は「Bot を作って `/start`」だけで最小、動作の確実性も高い。却下理由: `api_id`/`api_hash` の取得と対話ログインが必要で `chezmoi apply` だけでは再現できず、**アカウント全権のセッションファイル**を各 PC に置くことになる（Bot トークン漏洩とは影響度が桁違い）。追加依存（telethon）も発生する。→ **D2 の検証が失敗した場合の差し替え案として保持**（Migration Plan 参照）。
+- **案 C: Bot 1 個で往復** — 送信も受信も同一 Bot。Telegram の仕様上、自分が送ったメッセージの更新は届かないため成立しない。却下。
+- **案 D: Telegram は通知のみ、発話は案1/案2 のまま** — 実装は最小だが「SSH/devcontainer で発話できない」という当初の問題が解決しない。却下。
+- **案 E: 公開 ntfy.sh を案2 の URL に設定する** — 既存コードのままで到達性は得られるが、トピック名が実質的な共有秘密で誰でも購読でき、スマホ通知も別アプリになる。Telegram のほうが運用が素直。却下（ただし `voice` モードの案2 としては引き続き利用可能）。
+
+### D2: 送信 Bot と受信 Bot を分離する（Bot 2 個）
+
+同一 Bot を「チャンネル投稿者」と「グループ購読者」に兼用すると、自動転送されたコピーが *自分の投稿の派生* とみなされて配信されないリスクがある（仕様上のグレーゾーン）。加えて、リモート（devcontainer / 他人の環境に近い場所）に置くトークンは「チャンネルへ投稿する権限だけ」にしたい。よって:
+
+- **送信 Bot**: チャンネルの管理者。トークンはリモート含む全マシンの `config.env` に置く。漏洩時の最大被害は「チャンネルへ投稿される」こと。
+- **受信 Bot**: 連携グループのメンバー（プライバシーモード無効、または管理者）。トークンは手元マシンだけに置く。
+
+受信 Bot は 1 トークン 1 ポーラーに限る（`getUpdates` は同一トークンの並行呼び出しで HTTP 409）。Mac と Windows の両方で鳴らしたい場合は受信 Bot を 2 個作り、両方を同じグループに入れる（自動転送は両方に配信される）。
+
+### D3: メッセージ書式は「1 行目 = 発話文、2 行目 = マーカー行」
+
+```
+✅ dotfiles の作業が完了しました
+#claude_notify kind=done host=devbox repo=dotfiles sid=ab12cd34
+```
+
+- 1 行目をそのまま発話文にすることで、発話文の生成ロジック（`claude-notify-hook` のリポジトリ名付与）を送信側に集約でき、受信側は「整形して読むだけ」になる。JSON 本文にしないのは、スマホの通知プレビューで読めることを優先したため。
+- 2 行目のマーカーで「Claude Code 由来か」を判定する。人間の雑談や他アプリの投稿を誤って読み上げない防壁であり、将来 `kind` で挙動を分けるための拡張点でもある。`#claude_notify` をハッシュタグにしてあるので Telegram 側の検索・フィルタでも使える。
+- `parse_mode` は指定しない。Markdown/HTML パースを有効にすると、リポジトリ名に `_` や `*` が含まれた瞬間に 400 で送信失敗する。
+
+### D4: モードは `CLAUDE_NOTIFY_MODE`（`voice` | `telegram`、既定 `voice`）
+
+- 置き場所は既存様式に合わせて `~/.config/claude-notify/config.env`（`chezmoi.toml` の `[data.claudeNotify] mode`）。端末ごとに切り替わるのが自然（Mac は `voice`、devcontainer は `telegram` など）。
+- **`config.env` は `${VAR:-...}` 形式で出力する**。現行の `config.env` は `KEY="value"` で無条件代入しており、`. config.env` が既存の環境変数を踏み潰す。一時的な切り戻し（`CLAUDE_NOTIFY_MODE=voice claude-notify ...`）とデバッグを成立させるため、新規キーは環境変数優先で書き出す。
+- 不正値は `voice` として扱い警告のみ。通知系スクリプトがフックを失敗させてはならないため、どの失敗経路でも終了コードは 0。
+
+### D5: `telegram` モードでは nag を繰り返さない（grace 抑制は維持）
+
+- 繰り返しをそのまま Telegram 送信に置換すると 10 分毎にスマホが鳴りチャットも汚れる。ユーザー判断により `telegram` では 1 通のみ。
+- ただし grace（既定 3 秒）は残す。これは「turn 終了時の Notification → 直後の Stop」で確認メッセージを取り消す仕組みであり、無くすと完了 1 通＋不要な確認 1 通が毎回飛ぶ。`claude-notify-nag` の `start` を「grace 後 1 回だけ実行して終了」に分岐させるのが最小差分。
+- `voice` モードの nag（`CLAUDE_NAG_INTERVAL` 毎の再発話）は変更しない。
+
+### D6: 受信常駐は新規スクリプト 1 本（`claude-notify-daemon` に相乗りしない）
+
+`claude-notify-daemon` は案1（HTTP 受信）専用で、`telegram` モードでは不要。Windows では ntfy 購読を daemon に内包しているが、Telegram 受信を同じ場所に入れると「案1 を使わないのに daemon を常駐させる」ことになる。よって `claude-notify-telegram-bot` を独立させ、`claude-notify-ntfy-sub` と同じ「未設定なら休眠して exit 0」の作法に揃える。LaunchAgent / Startup VBS の生成コードは `claude-notify-daemon` と重複するが、単体で完結するスクリプトという既存方針（各スクリプトが自己完結）を優先する。
+
+Windows の停止処理は PID ファイル方式にする。既存 `claude-notify-daemon uninstall` は `taskkill /F /IM pythonw.exe` で全 `pythonw` を落とすため、新規スクリプトで同じことをすると相手を巻き込む。
+
+### D7: 受信側は「起動時バックログ破棄 + `offset` 永続化 + 鮮度フィルタ」
+
+スリープ復帰時に溜まった更新を全部読み上げると数分間喋り続ける。`offset` を `~/.local/state/claude-notify/telegram-offset` に永続化し、`date` が `CLAUDE_TELEGRAM_MAX_AGE`（既定 180 秒）より古いものは破棄する。発話は単一ワーカーで逐次実行（VOICEVOX に同時リクエストすると片方が失敗して `say` に落ちる既知問題があるため）。
+
+### D8: 発話呼び出しには `CLAUDE_NOTIFY_MODE=voice` を明示する
+
+受信側マシン自身の `config.env` が `telegram` だった場合、受信常駐が素朴に `claude-notify` を呼ぶと Telegram へ再送してループする。受信常駐は必ず `CLAUDE_NOTIFY_MODE=voice` を環境に入れて呼ぶ（D4 の環境変数優先と対になる設計）。
+
+## Risks / Trade-offs
+
+- **[最大リスク] チャンネル自動転送が受信 Bot に届かない可能性** → 実装着手前に curl だけで実機検証する（tasks 1.x）。成立しなければ案 B（Telethon 受信）へ差し替える。設計上、送信側の仕様（D3/D4/D5）と受信側の受理条件以外は共通なので、差し替え範囲は受信常駐 1 本に閉じる。
+- **通知内容が Telegram のサーバを経由する** → 本文はリポジトリ名・ホスト名・セッション ID 先頭 8 文字・固定文言のみに限定（`telegram-notify-send` の要件）。プロンプトやツール出力は送らない。それでも「どのリポジトリでいつ作業したか」は Telegram 上に残るため、`voice` モードを既定に据えたまま opt-in とする。
+- **送信 Bot トークンをリモートにも置く** → 権限はチャンネル投稿のみ。受信 Bot トークンは手元だけに置き、漏洩範囲を分離する（D2）。チャンネルは非公開にする。
+- **フック終端が最大 5 秒ブロックする**（`CLAUDE_TELEGRAM_TIMEOUT`） → 既存の案1 経路（4 秒）と同程度。回線不調時の体感悪化が許容できなければ、この値を下げるか将来的に非同期送信へ変更する。
+- **同一受信トークンの二重ポーリングで 409** → マシンごとに受信 Bot を分ける運用をドキュメント化し、常駐側は 409 を検知したらバックオフして警告を残す。
+- **Telegram 障害・オフライン時は無音**（ベルのみ） → 発話は本質的に「あると便利」な通知なので許容。恒久的に届かない環境では `voice` + 案1 に戻す。
+- **重複実装（LaunchAgent/VBS 生成が daemon と二重）** → 保守コスト増を受け入れる（D6）。将来 3 本目が必要になったら共通モジュール化を検討。
+
+## Migration Plan
+
+1. **実機検証（実装前）**: BotFather で送信 Bot・受信 Bot を作成、非公開チャンネルとディスカッショングループを作成して連携、送信 Bot をチャンネル管理者、受信 Bot をグループへ（プライバシーモード無効）。curl で `sendMessage`（チャンネル宛）→ `getUpdates`（受信 Bot）を叩き、`is_automatic_forward` / `sender_chat` 付きで取得できることを確認する。
+2. 失敗した場合は design を更新し、受信側を案 B（Telethon）に差し替える。送信側仕様と設定キーはそのまま流用する。
+3. 実装は「設定 → 送信側 → 受信側 → setup 結線 → ドキュメント」の順。各段階で `voice` モードの回帰（Mac ローカル発話、devcontainer の案1）を確認する。
+4. 展開は端末ごとに `chezmoi.toml` の `mode` を切り替えるだけ。ロールバックは `mode = "voice"` に戻して `chezmoi apply`（受信常駐は残っていても、送信が止まれば発話しない）。常駐を消すなら `claude-notify-telegram-bot uninstall`。
+5. 既存端末は `mode` 未設定 = `voice` なので、`chezmoi apply` しても挙動は変わらない。
+
+## Open Questions
+
+- 受信 Bot に「任意テキストを喋らせる」「`/mute` で一時停止」を持たせるか（今回は Non-Goal。マーカー判定を通らない投稿は無視する設計なので、後から追加しても既存動作と衝突しない）。
+- `telegram` モードでの nag を将来復活させる場合、繰り返しをリモート側で行うか（チャットが汚れる）受信側で行うか（cancel/resolve プロトコルが必要）。今回は無効で確定。
+- スマホ通知の静音化（`disable_notification`）を `kind=done` だけに適用するか。初期実装では両方とも通知あり。
+- 受信常駐を Linux デスクトップにも広げるか（現状は macOS / Windows のみ）。

--- a/openspec/changes/add-telegram-notify-transport/proposal.md
+++ b/openspec/changes/add-telegram-notify-transport/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Claude Code の Stop/Notification フックは現在「目の前のマシンで VOICEVOX を鳴らす」前提で作られている。SSH 先や devcontainer では自前のスピーカーが無いため、案1（Mac/Win の `claude-notify-daemon` に :50090 で POST）か案2（セルフホスト ntfy）でリレーしているが、案1 は環境ごとに経路設計（`host.docker.internal` / `RemoteForward` / LAN 公開 + 共有トークン）が必要で、案2 はサーバ運用が前提のため実質未構築。結果として「SSH/devcontainer では発話が届かない」状態が残っている。
+
+Telegram Bot API を経路にすると、ポート転送も自前サーバも無しにリモートから手元へメッセージを届けられ、同時にスマホへの通知も得られる。手元の PC 側に「Claude Code 由来のメッセージを受けたら VOICEVOX で発話する」常駐を置けば、既存の発話品質（VOICEVOX、日本語、リポジトリ名の読み上げ）をそのまま維持できる。
+
+## What Changes
+
+- 通知経路を選ぶ設定 `CLAUDE_NOTIFY_MODE`（`voice` | `telegram`、既定 `voice`）を追加する。どちらか一方のみが動作し、既定は現行動作そのままで非破壊。
+- `telegram` モードでは `claude-notify` はローカル発話を一切行わず、Telegram へ 1 通だけ送信する（送信本文の 1 行目が「発話される文」になる契約）。
+- 新規常駐 `claude-notify-telegram-bot`（macOS / Windows）を追加する。Telegram を長ポーリングし、**Claude Code 由来と判定できたメッセージだけ**を既存の発話経路（`claude-notify` → VOICEVOX / `claude-notify.ps1` → VOICEVOX→SAPI5）に渡す。
+- リレー構成は「送信 Bot が非公開チャンネルへ投稿 → Telegram が連携ディスカッショングループへ自動転送 → グループ内の受信 Bot が読む」を採用する（Bot は他 Bot / 自分自身の送信メッセージを `getUpdates` で受信できないため、単一 Bot の往復では成立しない）。送信用と受信用で **Bot を 2 つに分離**し、リモートには「チャンネルへ投稿する権限しかないトークン」だけを置く。
+- `telegram` モードでは nag（10 分毎の再催促）を無効化する。ただし turn 終了時の「確認をお願いします」を抑制する grace 遅延（既定 3 秒）は維持し、Telegram への無駄な 1 通を防ぐ。
+- `setup` / `setup.ps1` に opt-in の受信常駐インストール（`INSTALL_TELEGRAM_BOT=1` / `-TelegramBot`）、`config.env.tmpl` に設定キー、README に構成図・手順・トラブルシュートを追加する。
+- 既存の `voice` モード（macOS `say` フォールバック、Windows interop、案1 デーモン、案2 ntfy）はコードも既定値も変更しない。
+
+## Capabilities
+
+### New Capabilities
+- `notify-transport-selection`: 通知経路（`voice` / `telegram`）の選択と、設定値の解決順序・既定値・不正値の扱い。
+- `telegram-notify-send`: 送信側（Claude Code が動くマシン）の Telegram 送信仕様。メッセージ書式、送信先、タイムアウト、失敗時フォールバック、nag の扱い。
+- `telegram-voice-receiver`: 受信側（手元の macOS / Windows）常駐の仕様。受理条件（Claude Code 由来の判定）、発話、鮮度・重複制御、常駐ライフサイクル。
+
+### Modified Capabilities
+（なし。`openspec/specs/` は本変更で初期化されたばかりで、既存仕様ファイルは存在しない。既存 `voice` 経路の振る舞いは `notify-transport-selection` の回帰要件として記述する。）
+
+## Impact
+
+- `dot_local/bin/executable_claude-notify`: モード分岐と `notify_via_telegram()` の追加（`voice` 経路のロジックは不変）。
+- `dot_local/bin/executable_claude-notify-nag`: `telegram` モードでは grace 後 1 回だけ送って終了（繰り返さない）。
+- `dot_local/bin/executable_claude-notify-telegram-bot`: **新規**。Python 3 標準ライブラリのみ、`run` / `install` / `uninstall`（macOS: LaunchAgent、Windows: Startup VBS）。
+- `dot_config/claude-notify/config.env.tmpl`: `CLAUDE_NOTIFY_MODE` と Telegram 用キーを追加（環境変数が設定ファイルより優先されるよう `${VAR:-...}` 形式で出力）。
+- `setup` / `setup.ps1`: 受信常駐の opt-in インストール。
+- `README.md`: Telegram 経路の節を追加。
+- `.chezmoiignore`: `openspec`（本変更の管理ディレクトリを `$HOME` に配布しない）。
+- 無改修: `executable_claude-notify-hook`（`claude-notify` / `claude-notify-nag` を呼ぶだけ）、`claude-notify.ps1`（受信側がそのまま再利用）、`claude-notify-daemon`、`claude-notify-ntfy-sub`。
+- 外部依存: Telegram Bot API（HTTPS 到達性）。追加パッケージ（telethon 等）は採用案では不要。

--- a/openspec/changes/add-telegram-notify-transport/proposal.md
+++ b/openspec/changes/add-telegram-notify-transport/proposal.md
@@ -6,13 +6,14 @@ Telegram Bot API を経路にすると、ポート転送も自前サーバも無
 
 ## What Changes
 
-- 通知経路を選ぶ設定 `CLAUDE_NOTIFY_MODE`（`voice` | `telegram`、既定 `voice`）を追加する。どちらか一方のみが動作し、既定は現行動作そのままで非破壊。
+- 通知経路を選ぶ設定 `CLAUDE_NOTIFY_MODE`（`telegram` | `voice`、**既定 `telegram`**）を追加する。どちらか一方のみが動作する。**BREAKING**: 既定が `telegram` なので、`chezmoi apply` した既存端末は Telegram 経路へ切り替わる。従来どおり手元で直接発話したい端末は `[data.claudeNotify] mode = "voice"` を明示する。
+- 既定変更で無音になるのを防ぐため、`telegram` かつ Telegram の送信設定（トークン / チャット ID）が空の端末は、警告を 1 行出した上で `voice` 経路へフォールバックする（＝未配線端末は従来どおり鳴る）。
 - `telegram` モードでは `claude-notify` はローカル発話を一切行わず、Telegram へ 1 通だけ送信する（送信本文の 1 行目が「発話される文」になる契約）。
 - 新規常駐 `claude-notify-telegram-bot`（macOS / Windows）を追加する。Telegram を長ポーリングし、**Claude Code 由来と判定できたメッセージだけ**を既存の発話経路（`claude-notify` → VOICEVOX / `claude-notify.ps1` → VOICEVOX→SAPI5）に渡す。
 - リレー構成は「送信 Bot が非公開チャンネルへ投稿 → Telegram が連携ディスカッショングループへ自動転送 → グループ内の受信 Bot が読む」を採用する（Bot は他 Bot / 自分自身の送信メッセージを `getUpdates` で受信できないため、単一 Bot の往復では成立しない）。送信用と受信用で **Bot を 2 つに分離**し、リモートには「チャンネルへ投稿する権限しかないトークン」だけを置く。
 - `telegram` モードでは nag（10 分毎の再催促）を無効化する。ただし turn 終了時の「確認をお願いします」を抑制する grace 遅延（既定 3 秒）は維持し、Telegram への無駄な 1 通を防ぐ。
 - `setup` / `setup.ps1` に opt-in の受信常駐インストール（`INSTALL_TELEGRAM_BOT=1` / `-TelegramBot`）、`config.env.tmpl` に設定キー、README に構成図・手順・トラブルシュートを追加する。
-- 既存の `voice` モード（macOS `say` フォールバック、Windows interop、案1 デーモン、案2 ntfy）はコードも既定値も変更しない。
+- 既存の `voice` モードの経路選択ロジック（macOS `say` フォールバック、Windows interop、案1 デーモン、案2 ntfy）はコードを変更しない。変わるのは「どのモードが既定か」だけ。
 
 ## Capabilities
 

--- a/openspec/changes/add-telegram-notify-transport/specs/notify-transport-selection/spec.md
+++ b/openspec/changes/add-telegram-notify-transport/specs/notify-transport-selection/spec.md
@@ -1,19 +1,23 @@
 ## ADDED Requirements
 
 ### Requirement: 通知経路をモードで択一選択する
-`claude-notify` は設定値 `CLAUDE_NOTIFY_MODE` に従い、`voice`（既定）と `telegram` のいずれか一方の経路だけを使用しなければならない（SHALL）。両方を同時に実行してはならない（SHALL NOT）。未設定時は `voice` として扱い、既存端末の動作を変えてはならない（SHALL NOT）。
+`claude-notify` は設定値 `CLAUDE_NOTIFY_MODE` に従い、`telegram`（既定）と `voice` のいずれか一方の経路だけを使用しなければならない（SHALL）。両方を同時に実行してはならない（SHALL NOT）。未設定時は `telegram` として扱う（SHALL）。ただし Telegram の送信設定が未投入の端末が無音になるのを避けるため、`telegram` かつ送信設定が空の場合のみ `voice` 経路へフォールバックしなければならない（SHALL、詳細は `telegram-notify-send`）。
 
-#### Scenario: 未設定なら既存動作
-- **WHEN** `CLAUDE_NOTIFY_MODE` が設定ファイル・環境変数のいずれにも無い状態で `claude-notify "テスト"` を実行する
-- **THEN** 現行と同じ `voice` 経路（macOS: VOICEVOX→`say` / Windows: `claude-notify.ps1` / container・SSH: 案1→案2→ベル）で処理され、Telegram へは 1 通も送信されない
+#### Scenario: 未設定なら telegram
+- **WHEN** `CLAUDE_NOTIFY_MODE` が設定ファイル・環境変数のいずれにも無く、Telegram の送信設定が投入済みの端末で `claude-notify "テスト"` を実行する
+- **THEN** `telegram` 経路として Telegram へ 1 通だけ送信され、VOICEVOX / `say` / SAPI5 / `afplay` / `paplay` は一切呼ばれない
 
 #### Scenario: telegram モードではローカル発話しない
 - **WHEN** `CLAUDE_NOTIFY_MODE=telegram` で `claude-notify "テスト"` を実行する
 - **THEN** Telegram へ 1 通だけ送信され、VOICEVOX / `say` / SAPI5 / `afplay` / `paplay` は一切呼ばれない
 
+#### Scenario: voice を明示した端末は従来経路
+- **WHEN** `CLAUDE_NOTIFY_MODE=voice` で `claude-notify "テスト"` を実行する
+- **THEN** 現行と同じ `voice` 経路（macOS: VOICEVOX→`say` / Windows: `claude-notify.ps1` / container・SSH: 案1→案2→ベル）で処理され、Telegram へは 1 通も送信されない
+
 #### Scenario: 不正値は既定へフォールバック
 - **WHEN** `CLAUDE_NOTIFY_MODE=telegramm`（綴り誤り）で `claude-notify "テスト"` を実行する
-- **THEN** `voice` として処理され、警告を stderr に 1 行出力し、終了コードは 0 になる
+- **THEN** 既定の `telegram` として処理され、警告を stderr に 1 行出力し、終了コードは 0 になる
 
 ### Requirement: 設定値の解決順序
 モードおよび Telegram 関連の設定値は「環境変数 > `~/.config/claude-notify/config.env` > スクリプト既定値」の順で解決されなければならない（SHALL）。`config.env` は環境変数を上書きしてはならない（SHALL NOT）。
@@ -22,9 +26,13 @@
 - **WHEN** `config.env` に `CLAUDE_NOTIFY_MODE="telegram"` が入っている端末で `CLAUDE_NOTIFY_MODE=voice claude-notify "テスト"` を実行する
 - **THEN** `voice` 経路で処理される（一時的な切り戻し・デバッグが可能）
 
-#### Scenario: 端末ごとの既定値は chezmoi データで決まる
-- **WHEN** `~/.config/chezmoi/chezmoi.toml` に `[data.claudeNotify] mode = "telegram"` を書いて `chezmoi apply` する
-- **THEN** `~/.config/claude-notify/config.env` に `CLAUDE_NOTIFY_MODE` が `telegram` として出力され、その端末の既定モードになる
+#### Scenario: 端末ごとの上書きは chezmoi データで行う
+- **WHEN** `~/.config/chezmoi/chezmoi.toml` に `[data.claudeNotify] mode = "voice"` を書いて `chezmoi apply` する
+- **THEN** `~/.config/claude-notify/config.env` に `CLAUDE_NOTIFY_MODE` が `voice` として出力され、その端末だけ従来経路に固定される
+
+#### Scenario: chezmoi データ未記述なら telegram
+- **WHEN** `[data.claudeNotify] mode` を書かずに `chezmoi apply` する
+- **THEN** `config.env` の `CLAUDE_NOTIFY_MODE` は既定値 `telegram` として出力される
 
 ### Requirement: voice モードの既存動作を維持する
 本変更は `voice` モードの経路選択ロジック（macOS / native Windows / WSL2 interop / container・SSH の案1→案2→ローカルフォールバック）を変更してはならない（SHALL NOT）。

--- a/openspec/changes/add-telegram-notify-transport/specs/notify-transport-selection/spec.md
+++ b/openspec/changes/add-telegram-notify-transport/specs/notify-transport-selection/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: 通知経路をモードで択一選択する
+`claude-notify` は設定値 `CLAUDE_NOTIFY_MODE` に従い、`voice`（既定）と `telegram` のいずれか一方の経路だけを使用しなければならない（SHALL）。両方を同時に実行してはならない（SHALL NOT）。未設定時は `voice` として扱い、既存端末の動作を変えてはならない（SHALL NOT）。
+
+#### Scenario: 未設定なら既存動作
+- **WHEN** `CLAUDE_NOTIFY_MODE` が設定ファイル・環境変数のいずれにも無い状態で `claude-notify "テスト"` を実行する
+- **THEN** 現行と同じ `voice` 経路（macOS: VOICEVOX→`say` / Windows: `claude-notify.ps1` / container・SSH: 案1→案2→ベル）で処理され、Telegram へは 1 通も送信されない
+
+#### Scenario: telegram モードではローカル発話しない
+- **WHEN** `CLAUDE_NOTIFY_MODE=telegram` で `claude-notify "テスト"` を実行する
+- **THEN** Telegram へ 1 通だけ送信され、VOICEVOX / `say` / SAPI5 / `afplay` / `paplay` は一切呼ばれない
+
+#### Scenario: 不正値は既定へフォールバック
+- **WHEN** `CLAUDE_NOTIFY_MODE=telegramm`（綴り誤り）で `claude-notify "テスト"` を実行する
+- **THEN** `voice` として処理され、警告を stderr に 1 行出力し、終了コードは 0 になる
+
+### Requirement: 設定値の解決順序
+モードおよび Telegram 関連の設定値は「環境変数 > `~/.config/claude-notify/config.env` > スクリプト既定値」の順で解決されなければならない（SHALL）。`config.env` は環境変数を上書きしてはならない（SHALL NOT）。
+
+#### Scenario: 環境変数が設定ファイルに勝つ
+- **WHEN** `config.env` に `CLAUDE_NOTIFY_MODE="telegram"` が入っている端末で `CLAUDE_NOTIFY_MODE=voice claude-notify "テスト"` を実行する
+- **THEN** `voice` 経路で処理される（一時的な切り戻し・デバッグが可能）
+
+#### Scenario: 端末ごとの既定値は chezmoi データで決まる
+- **WHEN** `~/.config/chezmoi/chezmoi.toml` に `[data.claudeNotify] mode = "telegram"` を書いて `chezmoi apply` する
+- **THEN** `~/.config/claude-notify/config.env` に `CLAUDE_NOTIFY_MODE` が `telegram` として出力され、その端末の既定モードになる
+
+### Requirement: voice モードの既存動作を維持する
+本変更は `voice` モードの経路選択ロジック（macOS / native Windows / WSL2 interop / container・SSH の案1→案2→ローカルフォールバック）を変更してはならない（SHALL NOT）。
+
+#### Scenario: devcontainer での voice モード回帰
+- **WHEN** devcontainer 内（`/.dockerenv` あり）で `CLAUDE_NOTIFY_MODE=voice` として `claude-notify "テスト"` を実行する
+- **THEN** 案1（`http://host.docker.internal:50090/notify`）→案2（ntfy）→ローカルフォールバック（ベル）の順に、変更前と同じ順序で試行される
+
+#### Scenario: nag の grace 抑制はモードに依らず有効
+- **WHEN** turn 終了時に Notification と Stop がほぼ同時に発火する
+- **THEN** grace（既定 3 秒）内に `claude-notify-nag stop` が届いた「確認をお願いします」は、`voice` / `telegram` いずれのモードでも発話も送信もされない

--- a/openspec/changes/add-telegram-notify-transport/specs/telegram-notify-send/spec.md
+++ b/openspec/changes/add-telegram-notify-transport/specs/telegram-notify-send/spec.md
@@ -33,16 +33,31 @@
 - **WHEN** `api.telegram.org` へ到達できずタイムアウトする
 - **THEN** `CLAUDE_TELEGRAM_TIMEOUT` 秒で打ち切られ、リトライは行われない
 
-### Requirement: 失敗時と未設定時のフォールバック
-送信が失敗した場合、または `CLAUDE_TELEGRAM_BOT_TOKEN` / `CLAUDE_TELEGRAM_CHAT_ID` が空の場合、`claude-notify` はローカルフォールバック（端末ベル、可能なら通知音）のみを行い、`voice` 経路（VOICEVOX / say / 案1 / 案2）へ切り替えてはならない（SHALL NOT）。いずれの場合もフックを壊さないため終了コード 0 で終了しなければならない（SHALL）。
+### Requirement: 送信失敗時のフォールバック
+送信設定が投入済みで送信が失敗した場合、`claude-notify` はローカルフォールバック（端末ベル、可能なら通知音）のみを行い、`voice` 経路（VOICEVOX / say / 案1 / 案2）へ切り替えてはならない（SHALL NOT）。フックを壊さないため終了コード 0 で終了しなければならない（SHALL）。
 
 #### Scenario: 送信失敗
 - **WHEN** `telegram` モードでネットワークが切れている状態で通知が発生する
 - **THEN** ベルのみが鳴り、終了コードは 0、Claude Code の turn は妨げられない
 
-#### Scenario: 未設定端末
-- **WHEN** `CLAUDE_NOTIFY_MODE=telegram` だがトークンが空
-- **THEN** 送信は試みられず、stderr に 1 行の警告を出し、ベルのみで終了コード 0 になる
+#### Scenario: API がエラーを返す
+- **WHEN** チャット ID 誤りなどで `sendMessage` が 400 を返す
+- **THEN** リトライせずベルのみで終了コード 0 になり、stderr に 1 行の警告が残る
+
+### Requirement: 未設定端末は voice へフォールバックする
+既定モードが `telegram` であるため、`CLAUDE_TELEGRAM_BOT_TOKEN` または `CLAUDE_TELEGRAM_CHAT_ID` が空の端末（＝まだ Telegram を配線していない端末）では、`claude-notify` は stderr に 1 行の警告を出した上で `voice` 経路へフォールバックしなければならない（SHALL）。この場合も終了コードは 0 でなければならない（SHALL）。
+
+#### Scenario: 未配線の Mac
+- **WHEN** `CLAUDE_NOTIFY_MODE` 未設定（＝既定 `telegram`）でトークンが空の Mac で通知が発生する
+- **THEN** 送信は試みられず、警告 1 行の後に従来どおり VOICEVOX（不在時は `say`）で発話される
+
+#### Scenario: 未配線の devcontainer
+- **WHEN** 同じ状態の devcontainer で通知が発生する
+- **THEN** `voice` 経路として案1（デーモン）→案2（ntfy）→ベルの順に試行される
+
+#### Scenario: 設定済みなら択一を守る
+- **WHEN** トークンとチャット ID が投入済みの端末で通知が発生する
+- **THEN** Telegram 送信のみが行われ、送信の成否に依らず `voice` 経路は実行されない
 
 ### Requirement: telegram モードでは nag を繰り返さない
 `telegram` モードでは `claude-notify-nag start` は grace（`CLAUDE_NAG_GRACE`、既定 3 秒）後に 1 回だけ送信して終了しなければならない（SHALL）。`CLAUDE_NAG_INTERVAL` による繰り返し送信を行ってはならない（SHALL NOT）。`claude-notify-nag stop` は grace 中の 1 回目を取り消せなければならない（SHALL）。

--- a/openspec/changes/add-telegram-notify-transport/specs/telegram-notify-send/spec.md
+++ b/openspec/changes/add-telegram-notify-transport/specs/telegram-notify-send/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Telegram メッセージの書式
+`telegram` モードの送信本文は 2 行構成でなければならない（SHALL）。1 行目は「受信側が発話する文」、2 行目は機械可読なマーカー行とする。マーカー行は `#claude_notify` で始まり、空白区切りの `key=value` を並べる。
+
+```
+✅ dotfiles の作業が完了しました
+#claude_notify kind=done host=devbox repo=dotfiles sid=ab12cd34
+```
+
+`kind` は `done`（作業完了）または `confirm`（確認要求）、`host` は送信元ホスト名、`repo` はフックの cwd の git トップレベル名（無ければ省略）、`sid` はフック JSON の `session_id` 先頭 8 文字（無ければ省略）とする。1 行目の先頭には `kind` に応じた絵文字（`done`→`✅` / `confirm`→`🔔`）を付けてもよい（MAY）。本文全体は 4096 文字未満に切り詰めなければならない（SHALL）。
+
+#### Scenario: 完了通知の送信
+- **WHEN** `dotfiles` リポジトリで turn が終了し、`claude-notify-hook done` が `claude-notify "dotfilesの作業が完了しました"` を呼ぶ
+- **THEN** 1 行目が `✅ dotfilesの作業が完了しました`、2 行目が `#claude_notify kind=done host=<hostname> repo=dotfiles sid=<8桁>` のメッセージが 1 通送信される
+
+#### Scenario: 確認要求の送信
+- **WHEN** 権限プロンプト等で `claude-notify-hook notification` が発火し、grace 経過後に確認メッセージが送られる
+- **THEN** 1 行目が `🔔 dotfilesの確認をお願いします`、2 行目のマーカー行に `kind=confirm` を含むメッセージが 1 通送信される
+
+#### Scenario: git 管理外ディレクトリ
+- **WHEN** git リポジトリでない cwd から通知が発生する
+- **THEN** 1 行目はリポジトリ名を含まない既存の文言（例 `✅ 作業が完了しました`）となり、マーカー行から `repo=` が省略される
+
+### Requirement: 送信手段と宛先
+送信は Telegram Bot API の `sendMessage`（`https://api.telegram.org/bot<token>/sendMessage`）へ、`CLAUDE_TELEGRAM_BOT_TOKEN` と `CLAUDE_TELEGRAM_CHAT_ID`（リレー用チャンネル）を用いて行わなければならない（SHALL）。本文は書式崩れによる送信失敗を避けるためプレーンテキストで送り、`parse_mode` を指定してはならない（SHALL NOT）。1 回の通知につき送信は 1 回のみ試行し、タイムアウトは `CLAUDE_TELEGRAM_TIMEOUT` 秒（既定 5）を超えてはならない（SHALL NOT）。
+
+#### Scenario: 通常送信
+- **WHEN** トークンとチャット ID が設定済みで、ネットワークが正常
+- **THEN** `sendMessage` が 1 回だけ呼ばれ、フックは 5 秒以内に終了する
+
+#### Scenario: フックを遅延させない
+- **WHEN** `api.telegram.org` へ到達できずタイムアウトする
+- **THEN** `CLAUDE_TELEGRAM_TIMEOUT` 秒で打ち切られ、リトライは行われない
+
+### Requirement: 失敗時と未設定時のフォールバック
+送信が失敗した場合、または `CLAUDE_TELEGRAM_BOT_TOKEN` / `CLAUDE_TELEGRAM_CHAT_ID` が空の場合、`claude-notify` はローカルフォールバック（端末ベル、可能なら通知音）のみを行い、`voice` 経路（VOICEVOX / say / 案1 / 案2）へ切り替えてはならない（SHALL NOT）。いずれの場合もフックを壊さないため終了コード 0 で終了しなければならない（SHALL）。
+
+#### Scenario: 送信失敗
+- **WHEN** `telegram` モードでネットワークが切れている状態で通知が発生する
+- **THEN** ベルのみが鳴り、終了コードは 0、Claude Code の turn は妨げられない
+
+#### Scenario: 未設定端末
+- **WHEN** `CLAUDE_NOTIFY_MODE=telegram` だがトークンが空
+- **THEN** 送信は試みられず、stderr に 1 行の警告を出し、ベルのみで終了コード 0 になる
+
+### Requirement: telegram モードでは nag を繰り返さない
+`telegram` モードでは `claude-notify-nag start` は grace（`CLAUDE_NAG_GRACE`、既定 3 秒）後に 1 回だけ送信して終了しなければならない（SHALL）。`CLAUDE_NAG_INTERVAL` による繰り返し送信を行ってはならない（SHALL NOT）。`claude-notify-nag stop` は grace 中の 1 回目を取り消せなければならない（SHALL）。
+
+#### Scenario: 確認要求が 1 通で止まる
+- **WHEN** `telegram` モードで権限プロンプトが表示され、ユーザーが 30 分応答しない
+- **THEN** Telegram に送られる確認メッセージは 1 通だけで、10 分毎の再送は発生しない
+
+#### Scenario: turn 終了時の抑制
+- **WHEN** turn 終了に伴う Notification の直後（grace 内）に Stop フックが `nag stop` を呼ぶ
+- **THEN** 「確認をお願いします」は送信されず、`kind=done` のメッセージのみが送信される
+
+#### Scenario: voice モードの nag は不変
+- **WHEN** `CLAUDE_NOTIFY_MODE=voice` で権限プロンプトが表示され、応答しないまま放置する
+- **THEN** 従来どおり `CLAUDE_NAG_INTERVAL`（既定 600 秒）毎にローカルで再発話される
+
+### Requirement: 送信内容を通知文に限定する
+送信本文には既存の発話文（固定文言＋リポジトリ名）とマーカー行のメタデータ（ホスト名・リポジトリ名・セッション ID 先頭 8 文字・種別）以外を含めてはならない（SHALL NOT）。プロンプト本文、ツール出力、ファイルパス、フック JSON の生データを送信してはならない（SHALL NOT）。
+
+#### Scenario: 会話内容が外部へ出ない
+- **WHEN** 秘匿情報を含むプロンプトを扱っている session で通知が発生する
+- **THEN** 送信されるのは固定文言・リポジトリ名・ホスト名・セッション ID 先頭 8 文字のみで、会話内容は含まれない

--- a/openspec/changes/add-telegram-notify-transport/specs/telegram-voice-receiver/spec.md
+++ b/openspec/changes/add-telegram-notify-transport/specs/telegram-voice-receiver/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: 受信常駐のライフサイクル
+`claude-notify-telegram-bot` は `run` / `install` / `uninstall` のサブコマンドを持ち、`install` で手元マシンに常駐しなければならない（SHALL）。macOS では LaunchAgent（`com.claude.notify-telegram-bot`、`RunAtLoad` + `KeepAlive`、ログは `~/Library/Logs/claude-notify-telegram-bot.log`）、Windows ではスタートアップフォルダの VBS から `pythonw` を隠し起動する方式を用いなければならない（SHALL）。Python 3 標準ライブラリ以外の依存を追加してはならない（SHALL NOT）。
+
+#### Scenario: macOS への常駐
+- **WHEN** `claude-notify-telegram-bot install` を実行する
+- **THEN** LaunchAgent が書き出されて即座に起動し、再ログイン後も自動復帰する
+
+#### Scenario: Windows への常駐
+- **WHEN** `python %USERPROFILE%\.local\bin\claude-notify-telegram-bot install` を実行する
+- **THEN** スタートアップに VBS が置かれ、その場でも隠しプロセスとして起動する
+
+#### Scenario: 未設定なら休眠する
+- **WHEN** 受信用トークンまたはリレー先チャット ID が空の状態で `run` を実行する
+- **THEN** 何もせず 1 行のメッセージを出して終了コード 0 で終了する（`claude-notify-ntfy-sub` と同じ休眠挙動）
+
+#### Scenario: 停止は自分のプロセスだけ
+- **WHEN** 他の Python 常駐（`claude-notify-daemon` 等）が動いている Windows で `uninstall` を実行する
+- **THEN** 自身が記録した PID のプロセスのみが停止され、他の `pythonw.exe` は停止されない
+
+### Requirement: Claude Code 由来メッセージだけを受理する
+受信常駐は取得した更新のうち、次のすべてを満たすメッセージだけを発話対象としなければならない（SHALL）。(1) `chat.id` が `CLAUDE_TELEGRAM_RELAY_CHAT_ID`（連携ディスカッショングループ）と一致する、(2) `sender_chat.id` が `CLAUDE_TELEGRAM_SOURCE_CHAT_ID`（リレー用チャンネル）と一致する、または `is_automatic_forward` が真である、(3) 本文に `#claude_notify` で始まるマーカー行が含まれる。条件を満たさないメッセージは黙って無視しなければならない（SHALL）。
+
+#### Scenario: 正規のリレーを発話する
+- **WHEN** 送信 Bot がチャンネルへ投稿し、それが連携グループへ自動転送される
+- **THEN** 受信常駐がその更新を受理し、1 行目を発話する
+
+#### Scenario: 人間の雑談は発話しない
+- **WHEN** 同じグループでユーザーが任意のテキストを投稿する
+- **THEN** マーカー行が無いため無視され、発話は起こらない
+
+#### Scenario: 別チャットからの混入を弾く
+- **WHEN** マーカー行を含むメッセージが設定外のチャットから届く
+- **THEN** `chat.id` 不一致で無視される
+
+### Requirement: 発話は既存経路を再利用する
+発話はマーカー行を除いた 1 行目のテキストを整形（先頭の絵文字・記号の除去、連続空白の畳み込み、200 文字への切り詰め）した上で、macOS では `claude-notify`（`CLAUDE_NOTIFY_MODE=voice` を明示指定）、Windows では `claude-notify.ps1 -B64 <base64(UTF-8)>` に渡さなければならない（SHALL）。受信常駐が `claude-notify` を `telegram` モードで呼び出して再送ループを作ってはならない（SHALL NOT）。同時に複数メッセージが届いた場合は逐次再生し、VOICEVOX への同時リクエストで音声が重ならないようにしなければならない（SHALL）。
+
+#### Scenario: macOS で VOICEVOX が鳴る
+- **WHEN** 受理したメッセージの 1 行目が `✅ dotfilesの作業が完了しました`
+- **THEN** `dotfilesの作業が完了しました` が VOICEVOX（不在時は `say`）で読み上げられる
+
+#### Scenario: 再送ループを起こさない
+- **WHEN** 受信側マシンの `config.env` が `CLAUDE_NOTIFY_MODE=telegram` になっている
+- **THEN** 発話呼び出しには `CLAUDE_NOTIFY_MODE=voice` が明示され、Telegram への再送信は発生しない
+
+#### Scenario: 連続到着でも重ならない
+- **WHEN** 2 通のメッセージがほぼ同時に届く
+- **THEN** 1 通目の再生完了後に 2 通目が再生される
+
+### Requirement: 鮮度と重複の制御
+受信常駐は起動時に未処理分の滞留（バックログ）を破棄し、以後 `getUpdates` の `offset` を永続化して再起動後の重複発話を防がなければならない（SHALL）。`date` が `CLAUDE_TELEGRAM_MAX_AGE` 秒（既定 180）より古いメッセージは発話せず破棄しなければならない（SHALL）。
+
+#### Scenario: スリープ復帰で溜まった通知を捨てる
+- **WHEN** ノート PC を 3 時間スリープさせた後に復帰し、その間に 10 通の通知が溜まっている
+- **THEN** いずれも `MAX_AGE` 超過として破棄され、連続発話は起こらない
+
+#### Scenario: 再起動しても同じ通知を二度発話しない
+- **WHEN** 1 通を発話した直後に常駐を再起動する
+- **THEN** 永続化された `offset` により同じメッセージは再取得・再発話されない
+
+### Requirement: 障害耐性と単一受信者
+受信常駐は `getUpdates` の長ポーリング（`timeout` 50 秒程度）を用い、ネットワーク断・HTTP エラー時は指数バックオフ（初回 5 秒、上限 60 秒）で再接続を続けなければならない（SHALL）。HTTP 409（Conflict = 同一トークンで複数のポーラーが競合）を受けた場合は警告をログに出してバックオフしなければならない（SHALL）。同一の受信 Bot トークンで複数マシンが同時にポーリングしてはならない（SHALL NOT）。複数マシンで発話したい場合は受信 Bot をマシンごとに用意する。
+
+#### Scenario: 回線断からの自動復帰
+- **WHEN** Wi-Fi を 10 分切断し、その後復帰する
+- **THEN** 常駐は落ちずにバックオフ再接続し、復帰後の新規メッセージを発話する
+
+#### Scenario: トークン競合を検知できる
+- **WHEN** 同じ受信トークンで 2 台がポーリングする
+- **THEN** 409 が発生した側がログに警告を残し、無限に高頻度再試行しない

--- a/openspec/changes/add-telegram-notify-transport/tasks.md
+++ b/openspec/changes/add-telegram-notify-transport/tasks.md
@@ -1,0 +1,55 @@
+## 1. 実機検証（実装着手の前提）
+
+- [ ] 1.1 BotFather で送信 Bot と受信 Bot を作成し、受信 Bot は `/setprivacy` を Disable にする
+- [ ] 1.2 非公開チャンネルとディスカッショングループを作成して連携し、送信 Bot をチャンネル管理者、受信 Bot をグループに追加する
+- [ ] 1.3 `getUpdates` でチャンネル ID（`-100…`）とグループ ID を確認し、値を控える
+- [ ] 1.4 curl で送信 Bot からチャンネルへ 2 行のテストメッセージを `sendMessage`（`parse_mode` なし）して投稿できることを確認する
+- [ ] 1.5 受信 Bot の `getUpdates` で 1.4 の投稿が `chat.id`=グループ / `sender_chat.id`=チャンネル / `is_automatic_forward`=true として取得できることを確認する（**ここが失敗したら design.md の案 B（Telethon 受信）へ差し替えてから 3 章を再設計**）
+- [ ] 1.6 検証結果（取得できた JSON の要点、採用案 A/B の確定）を design.md の Migration Plan に追記する
+
+## 2. 設定とモード分岐（送信側）
+
+- [ ] 2.1 `dot_config/claude-notify/config.env.tmpl` に `CLAUDE_NOTIFY_MODE` / `CLAUDE_TELEGRAM_BOT_TOKEN` / `CLAUDE_TELEGRAM_CHAT_ID` / `CLAUDE_TELEGRAM_TIMEOUT` を追加し、すべて `${VAR:-<chezmoi値>}` 形式で出力して環境変数が優先されるようにする
+- [ ] 2.2 同ファイルのヘッダコメントに `[data.claudeNotify]` の新キー（`mode` / `telegramBotToken` / `telegramChatId` ほか）の書き方を追記する
+- [ ] 2.3 `executable_claude-notify` に `notify_via_telegram()` を追加する（`sendMessage`、プレーンテキスト、`--max-time $CLAUDE_TELEGRAM_TIMEOUT`、単発試行）
+- [ ] 2.4 `executable_claude-notify` の先頭でモードを解決し（`voice` 既定、不正値は警告して `voice`）、`telegram` のときは OS 分岐に入る前に送信して終了する経路を作る。ローカル発話は一切呼ばない
+- [ ] 2.5 `telegram` モードの失敗・未設定時は `local_fallback`（ベル）のみ実行し、終了コード 0 で終わることを保証する
+- [ ] 2.6 メッセージ本文を組み立てる（1 行目 = 絵文字 + 発話文、2 行目 = `#claude_notify kind=… host=… repo=… sid=…`、全体 4096 文字未満に切り詰め）。`kind` / `repo` / `sid` は `claude-notify-hook` から環境変数で受け渡す
+- [ ] 2.7 `executable_claude-notify-hook` から `kind`（done/confirm）・`repo`・`sid` を `claude-notify` へ渡す（発話文の生成箇所は変えない）
+- [ ] 2.8 `executable_claude-notify-nag` を `telegram` モードでは「grace 後 1 回だけ実行して終了」に分岐させる（`stop` が grace 中の 1 回目を取り消せることは維持）
+
+## 3. 受信常駐（手元 macOS / Windows）
+
+- [ ] 3.1 `dot_local/bin/executable_claude-notify-telegram-bot`（Python 3 標準ライブラリのみ）を新規作成し、`run` / `install` / `uninstall` の骨格と `config.env` 読み込み（既存環境変数を上書きしない）を実装する
+- [ ] 3.2 未設定（受信トークンまたはリレー先チャット ID が空）なら 1 行出力して exit 0 する休眠挙動を実装する
+- [ ] 3.3 `getUpdates` の長ポーリング（`timeout=50`、`allowed_updates=["message"]`）と指数バックオフ再接続（5→60 秒上限）、HTTP 409 の警告ログを実装する
+- [ ] 3.4 受理条件（`chat.id` 一致 / `sender_chat.id` 一致または `is_automatic_forward` / `#claude_notify` マーカー必須）を実装し、非該当は黙って無視する
+- [ ] 3.5 起動時のバックログ破棄、`offset` の永続化（`~/.local/state/claude-notify/telegram-offset`）、`CLAUDE_TELEGRAM_MAX_AGE`（既定 180 秒）超過の破棄を実装する
+- [ ] 3.6 発話テキストの整形（マーカー行除去、先頭絵文字・記号除去、空白畳み込み、200 文字切り詰め）を実装する
+- [ ] 3.7 発話呼び出しを実装する（macOS: `claude-notify` を `CLAUDE_NOTIFY_MODE=voice` 付きで、Windows: `claude-notify.ps1 -B64`）。単一ワーカーで逐次再生し、同時発話が重ならないようにする
+- [ ] 3.8 macOS の LaunchAgent（`com.claude.notify-telegram-bot`、`RunAtLoad`/`KeepAlive`、`~/Library/Logs/claude-notify-telegram-bot.log`）の install/uninstall を実装する
+- [ ] 3.9 Windows のスタートアップ VBS（`pythonw` 隠し起動）の install/uninstall を実装する。停止は PID ファイル方式にし、他の `pythonw.exe` を巻き込まないようにする
+
+## 4. セットアップ結線
+
+- [ ] 4.1 `setup` に `INSTALL_TELEGRAM_BOT=1` の opt-in 分岐を追加し、macOS で `claude-notify-telegram-bot install` を実行する（既定はスキップメッセージ）
+- [ ] 4.2 `setup.ps1` に `-TelegramBot` スイッチ（および `INSTALL_TELEGRAM_BOT=1`）を追加し、`claude-notify-telegram-bot install` を実行する
+- [ ] 4.3 `.chezmoiignore` に `openspec` を追加し、変更管理ディレクトリが `$HOME` へ配布されないようにする
+
+## 5. 検証
+
+- [ ] 5.1 `bash -n` で bash スクリプト、`python3 -m py_compile` で受信常駐の構文チェックを通す
+- [ ] 5.2 `chezmoi diff` で `config.env` / `settings.json` の出力差分を確認し、`mode` 未設定端末の出力が `voice` になることを確認する
+- [ ] 5.3 手元 Mac で `CLAUDE_NOTIFY_MODE=voice` の回帰確認（VOICEVOX 発話、`say` フォールバック、nag の 10 分繰り返し）
+- [ ] 5.4 devcontainer から `CLAUDE_NOTIFY_MODE=telegram` で completion / confirmation を発生させ、Telegram 到達 → 手元 Mac の発話までを確認する
+- [ ] 5.5 SSH 先から同様に確認する（ポート転送設定なしで届くこと）
+- [ ] 5.6 Windows を受信側にして同様に確認する（VOICEVOX 不在時に SAPI5 へ落ちること）
+- [ ] 5.7 異常系: トークン空 / ネットワーク切断 / 3 時間スリープ後の復帰（古い通知を読み上げない） / 同一トークン二重起動（409）を確認する
+- [ ] 5.8 受信側マシンの `config.env` が `telegram` でも再送ループが起きないことを確認する
+
+## 6. ドキュメント
+
+- [ ] 6.1 README に「Telegram 経由の通知（任意）」節を追加する（構成図、Bot 2 個・チャンネル・連携グループの作成手順、ID の取り方）
+- [ ] 6.2 `[data.claudeNotify]` の新キー一覧と `mode` の切り替え手順、`voice` へのロールバック手順を README に追記する
+- [ ] 6.3 トラブルシュート（何も喋らない / 409 / 古い通知が読まれる / プライバシーモード有効のまま / チャンネルとグループの ID を混同）を README に追記する
+- [ ] 6.4 セキュリティ注意（送信 Bot と受信 Bot の権限分離、非公開チャンネル、Telegram に残る情報の範囲）を README に追記する

--- a/openspec/changes/add-telegram-notify-transport/tasks.md
+++ b/openspec/changes/add-telegram-notify-transport/tasks.md
@@ -9,14 +9,15 @@
 
 ## 2. 設定とモード分岐（送信側）
 
-- [ ] 2.1 `dot_config/claude-notify/config.env.tmpl` に `CLAUDE_NOTIFY_MODE` / `CLAUDE_TELEGRAM_BOT_TOKEN` / `CLAUDE_TELEGRAM_CHAT_ID` / `CLAUDE_TELEGRAM_TIMEOUT` を追加し、すべて `${VAR:-<chezmoi値>}` 形式で出力して環境変数が優先されるようにする
+- [ ] 2.1 `dot_config/claude-notify/config.env.tmpl` に `CLAUDE_NOTIFY_MODE`（既定 `telegram`）/ `CLAUDE_TELEGRAM_BOT_TOKEN` / `CLAUDE_TELEGRAM_CHAT_ID` / `CLAUDE_TELEGRAM_TIMEOUT` を追加し、すべて `${VAR:-<chezmoi値>}` 形式で出力して環境変数が優先されるようにする
 - [ ] 2.2 同ファイルのヘッダコメントに `[data.claudeNotify]` の新キー（`mode` / `telegramBotToken` / `telegramChatId` ほか）の書き方を追記する
 - [ ] 2.3 `executable_claude-notify` に `notify_via_telegram()` を追加する（`sendMessage`、プレーンテキスト、`--max-time $CLAUDE_TELEGRAM_TIMEOUT`、単発試行）
-- [ ] 2.4 `executable_claude-notify` の先頭でモードを解決し（`voice` 既定、不正値は警告して `voice`）、`telegram` のときは OS 分岐に入る前に送信して終了する経路を作る。ローカル発話は一切呼ばない
-- [ ] 2.5 `telegram` モードの失敗・未設定時は `local_fallback`（ベル）のみ実行し、終了コード 0 で終わることを保証する
-- [ ] 2.6 メッセージ本文を組み立てる（1 行目 = 絵文字 + 発話文、2 行目 = `#claude_notify kind=… host=… repo=… sid=…`、全体 4096 文字未満に切り詰め）。`kind` / `repo` / `sid` は `claude-notify-hook` から環境変数で受け渡す
-- [ ] 2.7 `executable_claude-notify-hook` から `kind`（done/confirm）・`repo`・`sid` を `claude-notify` へ渡す（発話文の生成箇所は変えない）
-- [ ] 2.8 `executable_claude-notify-nag` を `telegram` モードでは「grace 後 1 回だけ実行して終了」に分岐させる（`stop` が grace 中の 1 回目を取り消せることは維持）
+- [ ] 2.4 `executable_claude-notify` の先頭でモードを解決し（既定 `telegram`、不正値は警告して既定扱い）、`telegram` のときは OS 分岐に入る前に送信して終了する経路を作る。ローカル発話は一切呼ばない
+- [ ] 2.5 `telegram` モードで送信が失敗したときは `local_fallback`（ベル）のみ実行し、終了コード 0 で終わることを保証する
+- [ ] 2.6 `telegram` モードでトークンまたはチャット ID が空のときは、警告 1 行の後に `voice` 経路へフォールバックする（既定モード変更で未配線端末が無音にならないようにする）
+- [ ] 2.7 メッセージ本文を組み立てる（1 行目 = 絵文字 + 発話文、2 行目 = `#claude_notify kind=… host=… repo=… sid=…`、全体 4096 文字未満に切り詰め）。`kind` / `repo` / `sid` は `claude-notify-hook` から環境変数で受け渡す
+- [ ] 2.8 `executable_claude-notify-hook` から `kind`（done/confirm）・`repo`・`sid` を `claude-notify` へ渡す（発話文の生成箇所は変えない）
+- [ ] 2.9 `executable_claude-notify-nag` を `telegram` モードでは「grace 後 1 回だけ実行して終了」に分岐させる（`stop` が grace 中の 1 回目を取り消せることは維持）
 
 ## 3. 受信常駐（手元 macOS / Windows）
 
@@ -39,17 +40,17 @@
 ## 5. 検証
 
 - [ ] 5.1 `bash -n` で bash スクリプト、`python3 -m py_compile` で受信常駐の構文チェックを通す
-- [ ] 5.2 `chezmoi diff` で `config.env` / `settings.json` の出力差分を確認し、`mode` 未設定端末の出力が `voice` になることを確認する
+- [ ] 5.2 `chezmoi diff` で `config.env` の出力差分を確認し、`mode` 未記述端末の出力が `telegram` になること、`mode = "voice"` を書いた端末は `voice` になることを確認する
 - [ ] 5.3 手元 Mac で `CLAUDE_NOTIFY_MODE=voice` の回帰確認（VOICEVOX 発話、`say` フォールバック、nag の 10 分繰り返し）
 - [ ] 5.4 devcontainer から `CLAUDE_NOTIFY_MODE=telegram` で completion / confirmation を発生させ、Telegram 到達 → 手元 Mac の発話までを確認する
 - [ ] 5.5 SSH 先から同様に確認する（ポート転送設定なしで届くこと）
 - [ ] 5.6 Windows を受信側にして同様に確認する（VOICEVOX 不在時に SAPI5 へ落ちること）
-- [ ] 5.7 異常系: トークン空 / ネットワーク切断 / 3 時間スリープ後の復帰（古い通知を読み上げない） / 同一トークン二重起動（409）を確認する
+- [ ] 5.7 異常系: トークン空（＝`voice` へフォールバックして鳴る）/ ネットワーク切断（ベルのみ）/ 3 時間スリープ後の復帰（古い通知を読み上げない）/ 同一トークン二重起動（409）を確認する
 - [ ] 5.8 受信側マシンの `config.env` が `telegram` でも再送ループが起きないことを確認する
 
 ## 6. ドキュメント
 
 - [ ] 6.1 README に「Telegram 経由の通知（任意）」節を追加する（構成図、Bot 2 個・チャンネル・連携グループの作成手順、ID の取り方）
-- [ ] 6.2 `[data.claudeNotify]` の新キー一覧と `mode` の切り替え手順、`voice` へのロールバック手順を README に追記する
+- [ ] 6.2 `[data.claudeNotify]` の新キー一覧、既定が `telegram` である旨、`mode = "voice"` で端末単位に opt-out / ロールバックする手順を README に追記する
 - [ ] 6.3 トラブルシュート（何も喋らない / 409 / 古い通知が読まれる / プライバシーモード有効のまま / チャンネルとグループの ID を混同）を README に追記する
 - [ ] 6.4 セキュリティ注意（送信 Bot と受信 Bot の権限分離、非公開チャンネル、Telegram に残る情報の範囲）を README に追記する

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## 概要

SSH 先 / devcontainer で Claude Code の通知が発話できない問題に対して、**通知を Telegram に送り、手元 PC の常駐 bot が VOICEVOX で発話する**経路を追加する仕様をまとめた。

このブランチに入っているのは **OpenSpec の変更提案（ドキュメント）のみ**で、`claude-notify` 系スクリプトの実装は未着手。実機検証（後述）を済ませてから実装に入る想定。

- 変更: `openspec/changes/add-telegram-notify-transport/`（proposal / design / specs×3 / tasks）、`.chezmoiignore` に `openspec` を追加
- `openspec validate add-telegram-notify-transport --strict` は通過（artifacts 4/4 complete）
- 既存スクリプトの挙動は**このブランチでは一切変わらない**

## 調査で判明した制約（設計の分岐点）

**Telegram の Bot は、他の Bot および自分自身が送信したメッセージを `getUpdates` で受信できない**（ループ防止のための仕様）。そのため「フックが Bot で送信 → 端末内の Bot がそれを読んで発話」は素直には成立せず、送信者が Bot ではない identity を挟む必要がある。

## 採用した構成

```
hook → 送信Bot(sendMessage) → 非公開チャンネル        ← スマホ通知はここから届く
                                   │ Telegram が自動転送（sender_chat = チャンネル）
                                   ▼
                             連携ディスカッショングループ
                                   │ getUpdates 長ポーリング
                                   ▼
                    claude-notify-telegram-bot（手元 Mac/Win 常駐）→ VOICEVOX
```

| 決定 | 内容 |
| --- | --- |
| リレー方式 | チャンネル → 連携グループの自動転送を挟み、Bot API だけで成立させる（追加依存・ユーザーセッション不要）。代替案の Telethon 受信は design.md に記載 |
| Bot 構成 | 送信用と受信用で **Bot を 2 つに分離**。リモートには「チャンネルへ投稿する権限だけ」のトークンを置く |
| 本文書式 | 1 行目＝発話文、2 行目＝`#claude_notify kind=… host=… repo=… sid=…`。スマホでも読めて、受信側が Claude Code 由来を判定できる。`parse_mode` は付けない（リポジトリ名の `_` で 400 になるため） |
| モード | `CLAUDE_NOTIFY_MODE` = `telegram`（**既定**）/ `voice` の択一。`voice` は端末ごとに `[data.claudeNotify] mode = "voice"` で opt-out |
| 未配線端末 | 既定 telegram のままトークン未投入だと無音になるため、トークン/チャット ID が空のときだけ警告付きで `voice` へフォールバック。設定済みで送信失敗した場合はベルのみ（`voice` には落とさない） |
| nag | `telegram` では 10 分毎の再送を無効化（1 通のみ）。turn 終了時の「確認」を打ち消す grace 3 秒は維持 |
| 受信側の安全策 | 再送ループ防止（`CLAUDE_NOTIFY_MODE=voice` を明示して発話）、スリープ復帰時の一斉読み上げ防止（鮮度 180 秒＋`offset` 永続化）、逐次再生、409 検知、Windows の停止は PID ファイル方式（既存 daemon の `taskkill /IM pythonw.exe` は踏襲しない） |
| 送信内容 | 固定文言＋リポジトリ名・ホスト名・session_id 先頭 8 桁のみ。プロンプトやツール出力は送らない |

**BREAKING**: 既定が `telegram` なので、`chezmoi apply` した既存端末は Telegram 経路に切り替わる（未配線の間は `voice` にフォールバックするため無音にはならない）。従来どおり手元で直接鳴らしたい端末は `mode = "voice"` を明示する。

## ローカルで続きを進める手順

### 1. Bot・チャンネル・グループを用意する

<details>
<summary>BotFather と Telegram アプリ側の設定（クリックで展開）</summary>

@BotFather で Bot を 2 つ作る:

```
/newbot  →  Claude Notify Sender   例) claude_notify_send_bot   → トークン控える（SENDER）
/newbot  →  Claude Notify Speaker  例) claude_notify_speak_bot  → トークン控える（RECEIVER）
/setprivacy → 受信Bot を選択 → Disable        ← 受信Botのみ。必須
```

チャンネルとグループ:

1. 非公開チャンネルを作成（例 `Claude Notify`）
2. チャンネルに **SENDER Bot を管理者として追加**（`Post Messages` のみ ON）
   - チャンネル名タップ → 編集 → 管理者 → 管理者を追加 → **ユーザー名で検索**（Bot は一覧に出ない）
3. グループを作成（例 `Claude Notify Discussion`）
4. チャンネル設定 → Discussion → 3 のグループを連携
5. グループに **RECEIVER Bot を追加**（管理者にしておくと確実）
   - `/setprivacy` の変更がグループ追加より後だった場合は、Bot を一度外して再追加する

管理者になれたかの確認（`BOT_ID` はトークンの `:` より前の数字）:

```bash
SENDER=<送信Botトークン>; BOT_ID=${SENDER%%:*}; CHANNEL_ID=-100xxxxxxxxxx
curl -s "https://api.telegram.org/bot$SENDER/getChatMember?chat_id=$CHANNEL_ID&user_id=$BOT_ID" | python3 -m json.tool
# "status": "administrator" かつ "can_post_messages": true なら OK
```

</details>

### 2. 実機検証（tasks 1章 / 実装着手の前提）

判定したいのは 1 点だけ: **チャンネルへの投稿が、受信 Bot の `getUpdates` で読めるか**。

<details>
<summary>ID 取得 → 送信 → 受信の curl 手順（クリックで展開）</summary>

```bash
SENDER=<送信Botトークン>
RECEIVER=<受信Botトークン>

# ID を調べる（チャンネル / グループで一度何か発言してから叩く）
curl -s "https://api.telegram.org/bot$SENDER/getUpdates"   | python3 -m json.tool | grep -A3 '"chat"'
curl -s "https://api.telegram.org/bot$RECEIVER/getUpdates" | python3 -m json.tool | grep -A3 '"chat"'
# type: channel 側 → CHANNEL_ID / type: supergroup 側 → GROUP_ID

CHANNEL_ID=-100xxxxxxxxxx
GROUP_ID=-100yyyyyyyyyy

# 送信テスト（parse_mode は付けない）
curl -s -X POST "https://api.telegram.org/bot$SENDER/sendMessage" \
  --data-urlencode "chat_id=$CHANNEL_ID" \
  --data-urlencode 'text=✅ dotfilesの作業が完了しました
#claude_notify kind=done host=testbox repo=dotfiles sid=ab12cd34' \
  | python3 -m json.tool | head -20

# 受信テスト（本命の判定）
curl -s "https://api.telegram.org/bot$RECEIVER/getUpdates" | python3 -c '
import json,sys
for u in json.load(sys.stdin).get("result",[]):
    m = u.get("message") or {}
    print("update_id      :", u.get("update_id"))
    print("  chat.id      :", (m.get("chat") or {}).get("id"), (m.get("chat") or {}).get("type"))
    print("  sender_chat  :", (m.get("sender_chat") or {}).get("id"))
    print("  auto_forward :", m.get("is_automatic_forward"))
    print("  text[0]      :", (m.get("text") or "").splitlines()[:1])
'
```

**合格条件（3 つすべて）**: `chat.id` == `GROUP_ID` / `sender_chat` == `CHANNEL_ID` / `is_automatic_forward` == `True`

| 症状 | 対処 |
| --- | --- |
| `chat not found` | `CHANNEL_ID` 違い、または SENDER が管理者でない |
| `result: []`（グループ発言も拾えない） | 受信 Bot の privacy mode が有効のまま → Disable にして Bot を再追加 |
| 自分の発言は拾えるが**自動転送だけ拾えない** | 案 A 不成立 → design.md の**案 B（Telethon 受信）へ差し替え**。送信側仕様と設定キーは流用でき、差し替えは受信常駐 1 本に閉じる |
| `409 Conflict` | 同一トークンで別の `getUpdates` が動いている |

</details>

### 3. 検証後

- 結果（取れた JSON の要点と採用案の確定）を `design.md` の Migration Plan に追記（tasks 1.6）
- `/openspec-apply-change add-telegram-notify-transport` で 2 章以降（設定 → 送信側 → 受信側 → setup 結線 → 検証 → README）を実装

## 未決事項

- 受信 Bot に「任意テキストの読み上げ」「`/mute`」を持たせるか（今回は Non-Goal。マーカー判定を通らない投稿は無視する設計なので後付け可能）
- `kind=done` だけ `disable_notification` にするか（初期実装は両方とも通知あり）
- 受信常駐の Linux デスクトップ対応（現状 macOS / Windows のみ）

## レビュー観点

- 既定を `telegram` にしたことの是非（未配線端末は `voice` フォールバックで無音回避）
- 送信本文に含める情報の範囲（リポジトリ名・ホスト名を Telegram に残してよいか）
- フック終端が最大 5 秒ブロックし得る点（`CLAUDE_TELEGRAM_TIMEOUT`、既存の案1 経路は 4 秒）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaiEeamMv225TGY9LF6JZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaiEeamMv225TGY9LF6JZe)_